### PR TITLE
Fix packaging requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(name='var',
       version=get_version(),
       description='Different Methods to Estimate the Value-at-Risk of a portfolio.',
       packages=get_packages(),
-
+      install_requires=required,
       author="Ismail Baris",
       maintainer='Ismail Baris',
       author_email='i.baris@outlook.de',

--- a/var/.version/version.dat
+++ b/var/.version/version.dat
@@ -18,3 +18,4 @@ Date: 2021/06/28:17:47
 2021/07/11:14:15;bari_is;0.0.3-beta+Sanders
 2021/07/11:14:53;bari_is;0.0.4-beta+Sanders
 2021/10/09:10:49;bari_is;0.0.5-beta+Sanders
+2023/02/05:03:47;bari_is;0.0.6-beta+Sanders

--- a/var/.version/version.dat
+++ b/var/.version/version.dat
@@ -18,4 +18,4 @@ Date: 2021/06/28:17:47
 2021/07/11:14:15;bari_is;0.0.3-beta+Sanders
 2021/07/11:14:53;bari_is;0.0.4-beta+Sanders
 2021/10/09:10:49;bari_is;0.0.5-beta+Sanders
-2023/02/05:03:47;bari_is;0.0.6-beta+Sanders
+2023/02/05:03:47;MatthewBurke;0.0.6-beta+Sanders


### PR DESCRIPTION
This is a minor fix, it looks like there was a single missing line from setup.py to download the packages from requirements.txt. The `required` variable was created but wasn't used, which means this change is a one-liner.

Previously `python setup.py install` would only install `VaR==0.05`, with the PR changes it will install `VaR` and all the packages in requirements.txt.